### PR TITLE
fix: formatting in JIT bubble text

### DIFF
--- a/patches/trivalent/ui/register-new-strings.patch
+++ b/patches/trivalent/ui/register-new-strings.patch
@@ -20,7 +20,7 @@ index 384521cdbe..8229efaeb6 100644
  If this page isn’t working as expected, try allowing optimization.
 +      </message>
 +      <message name="IDS_JS_JIT_BUBBLE_BODY_NON_POLICY_BODY" desc="Body text for the JavaScript optimization bubble when disabled for other reasons.">
-+        For security, Chromium turns off JavaScript JIT by default.&#xA;.&#xA;
++        For security, Chromium turns off JavaScript JIT by default.&#xA;
 +If this page isn’t working as expected, try allowing JIT.
        </message>
        <!-- Send Tab To Self -->


### PR DESCRIPTION
Removes `.&#xA;`. Hopefully this is the right thing to do?

The JIT bubble text is currently slightly broken:

<img width="346" height="326" alt="Screenshot From 2026-08-25 17-19-54" src="https://github.com/user-attachments/assets/f0ba896f-69f1-4844-baeb-72a14c24dee7" />
